### PR TITLE
Add ClawBench to Agent applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Related projects:
 5. ToolLLM: Facilitating Large Language Models to Master 16000+ Real-world APIs. _Qin et al._ arXiv 2023. [[paper](https://arxiv.org/abs/2307.16789)]
 6. Toolformer: Language Models Can Teach Themselves to Use Tools. _Timo Schick et al._ arXiv 2023. [[paper](https://arxiv.org/abs/2302.04761)]
 7. HuggingGPT: Solving AI Tasks with ChatGPT and its Friends in Hugging Face. _Yongliang Shen et al._ arXiv 2023. [[paper](https://arxiv.org/abs/2303.17580)]
+8. ClawBench: Evaluating Browser Agents on Live Production Websites. _NAIL Group._ arXiv 2026. [[paper](https://arxiv.org/abs/2604.08523)] [[GitHub](https://github.com/reacher-z/ClawBench)]
 
 ### Other applications
 


### PR DESCRIPTION
Adding ClawBench to the `Agent applications` section.

**Entry added** (line 295):
> 8. ClawBench: Evaluating Browser Agents on Live Production Websites. _NAIL Group._ arXiv 2026. [[paper](https://arxiv.org/abs/2604.08523)] [[GitHub](https://github.com/reacher-z/ClawBench)]

**Section fit:** The "Agent applications" subsection lists Tool Learning, ToolLLM, Toolformer, HuggingGPT, and similar LLM-agent works. ClawBench evaluates LLM agents in a browser-agent setting, so it belongs alongside these entries.

**Benchmark summary:**
- 153 everyday web tasks on 144 live production websites across 15 life categories
- 7 frontier models evaluated; best passes 33.3%
- Unique mechanism: a submission-interception layer (Chrome extension + CDP) blocks only the final write request, so agents complete end-to-end flows on live sites without real-world side effects (no real orders, emails, applications)

**Links:**
- Paper: https://arxiv.org/abs/2604.08523
- Repo: https://github.com/reacher-z/ClawBench
- Dataset: https://huggingface.co/datasets/NAIL-Group/ClawBench
- Site: https://claw-bench.com

Format matches the neighboring entries in the section.

Disclosure: I am affiliated with the ClawBench project.